### PR TITLE
Fix duplicate deletion of participant availabilities

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -182,12 +182,6 @@ export async function submitAvailability(formData: FormData) {
       }
     }
 
-    // 既存の参加者の回答を削除
-    await supabase
-      .from("availabilities")
-      .delete()
-      .eq("participant_id", existingParticipantId)
-      .eq("event_id", eventId);
 
     // フォームデータから利用可能時間を収集
     const availabilityEntries = [];


### PR DESCRIPTION
## Summary
- remove redundant deletion in `submitAvailability`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683fe4aeed44832a8967f38c2289bf67