### PR TITLE
Fix calendar API to use correct date fields

### DIFF
--- a/src/app/api/calendar/route.ts
+++ b/src/app/api/calendar/route.ts
@@ -37,7 +37,7 @@ export async function GET(request: NextRequest) {
     // 確定した日程の取得
     const { data: finalDate, error: dateError } = await supabase
       .from("event_dates")
-      .select("date_time")
+      .select("start_time, end_time")
       .eq("id", event.final_date_id)
       .single();
 
@@ -47,9 +47,11 @@ export async function GET(request: NextRequest) {
     }
 
     // ICSファイルの生成
-    const eventDate = new Date(finalDate.date_time);
-    // 終了時間は開始時間の1時間後をデフォルトとする
-    const eventEndDate = new Date(eventDate.getTime() + 60 * 60 * 1000);
+    const eventDate = new Date(finalDate.start_time);
+    // 終了時間があればそれを使用、なければ開始から1時間後をデフォルトとする
+    const eventEndDate = finalDate.end_time
+      ? new Date(finalDate.end_time)
+      : new Date(eventDate.getTime() + 60 * 60 * 1000);
 
     const now = new Date();
     const icsContent = [


### PR DESCRIPTION
## Summary
- fix event date query in `/api/calendar` route
- use start/end times to build ICS files

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_683fe49a4188832a826ae0e5dff0b795