### PR TITLE
[fix] work: last_accessed_at default

### DIFF
--- a/supabase/migrations/20250604000000_add_transaction_functions.sql
+++ b/supabase/migrations/20250604000000_add_transaction_functions.sql
@@ -72,8 +72,8 @@ DECLARE
   date_record jsonb;
 BEGIN
   -- イベントを作成
-  INSERT INTO events (title, description, public_token, admin_token, last_accessed_at)
-  VALUES (p_title, p_description, p_public_token, p_admin_token, now())
+  INSERT INTO events (title, description, public_token, admin_token)
+  VALUES (p_title, p_description, p_public_token, p_admin_token)
   RETURNING id INTO new_event_id;
 
   -- 候補日程を挿入

--- a/supabase/migrations/20250605_set_last_accessed_default.sql
+++ b/supabase/migrations/20250605_set_last_accessed_default.sql
@@ -6,3 +6,48 @@ ALTER TABLE events
 UPDATE events
   SET last_accessed_at = created_at
   WHERE last_accessed_at IS NULL;
+
+-- create_event_with_dates 関数に last_accessed_at の設定を追加
+CREATE OR REPLACE FUNCTION create_event_with_dates(
+  p_title text,
+  p_description text,
+  p_public_token uuid,
+  p_admin_token uuid,
+  p_event_dates jsonb
+)
+RETURNS TABLE (
+  event_id uuid,
+  public_token uuid,
+  admin_token uuid
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  new_event_id uuid;
+  date_record jsonb;
+BEGIN
+  -- イベントを作成
+  INSERT INTO events (title, description, public_token, admin_token, last_accessed_at)
+  VALUES (p_title, p_description, p_public_token, p_admin_token, now())
+  RETURNING id INTO new_event_id;
+
+  -- 候補日程を挿入
+  FOR date_record IN SELECT * FROM jsonb_array_elements(p_event_dates)
+  LOOP
+    INSERT INTO event_dates (event_id, start_time, end_time)
+    VALUES (
+      new_event_id,
+      (date_record->>'start_time')::timestamp,
+      (date_record->>'end_time')::timestamp
+    );
+  END LOOP;
+
+  -- 結果を返す
+  RETURN QUERY SELECT new_event_id, p_public_token, p_admin_token;
+
+EXCEPTION
+  WHEN OTHERS THEN
+    RAISE;
+END;
+$$;


### PR DESCRIPTION
## 背景
古いイベントを自動削除する処理で、`last_accessed_at` が NULL のまま生成されたイベントが誤って対象になっていました。新規作成時に値が入らないためです。

## 変更点
- イベント作成 RPC `create_event_with_dates` で `last_accessed_at` に `now()` を設定
- `last_accessed_at` のデフォルト値を `now()` にするマイグレーションを追加

## テスト
- `npm run lint`
- `npm run test:ci`
- `npm run e2e` *(環境制約により失敗)*

------
https://chatgpt.com/codex/tasks/task_e_68405b4a0fe0832aa8ee5d8498c15b77