### PR TITLE
[test] feature/expand-tests: テストカバレッジ拡充

### DIFF
--- a/src/lib/__tests__/device-utils.test.ts
+++ b/src/lib/__tests__/device-utils.test.ts
@@ -1,0 +1,37 @@
+import { isMobileDevice, isIOS, isAndroid, isStandalone } from '../utils';
+
+describe('デバイス判定ユーティリティ', () => {
+  const originalUA = navigator.userAgent;
+  const originalMatchMedia = window.matchMedia;
+  const originalStandalone = (navigator as Navigator & { standalone?: boolean }).standalone;
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'userAgent', { value: originalUA, configurable: true });
+    window.matchMedia = originalMatchMedia;
+    (navigator as Navigator & { standalone?: boolean }).standalone = originalStandalone;
+  });
+
+  it('iPhone UA を検出できる', () => {
+    Object.defineProperty(navigator, 'userAgent', { value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X)', configurable: true });
+    expect(isMobileDevice()).toBe(true);
+    expect(isIOS()).toBe(true);
+    expect(isAndroid()).toBe(false);
+  });
+
+  it('Android UA を検出できる', () => {
+    Object.defineProperty(navigator, 'userAgent', { value: 'Mozilla/5.0 (Linux; Android 10)', configurable: true });
+    expect(isMobileDevice()).toBe(true);
+    expect(isAndroid()).toBe(true);
+    expect(isIOS()).toBe(false);
+  });
+
+  it('スタンドアロン判定はmatchMediaとstandaloneで動作する', () => {
+    window.matchMedia = jest.fn().mockReturnValue({ matches: true });
+    expect(isStandalone()).toBe(true);
+    window.matchMedia = jest.fn().mockReturnValue({ matches: false });
+    (navigator as Navigator & { standalone?: boolean }).standalone = true;
+    expect(isStandalone()).toBe(true);
+    (navigator as Navigator & { standalone?: boolean }).standalone = false;
+    expect(isStandalone()).toBe(false);
+  });
+});

--- a/src/lib/__tests__/dom-utils.test.ts
+++ b/src/lib/__tests__/dom-utils.test.ts
@@ -1,0 +1,20 @@
+import { ensurePortal } from '../dom-utils';
+
+describe('ensurePortal', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('要素が存在しない場合は生成される', () => {
+    const el = ensurePortal('test-portal');
+    expect(el.id).toBe('test-portal');
+    expect(document.getElementById('test-portal')).toBe(el);
+  });
+
+  it('既存要素がある場合はそれを返す', () => {
+    const first = ensurePortal('dup');
+    const second = ensurePortal('dup');
+    expect(first).toBe(second);
+    expect(document.querySelectorAll('#dup').length).toBe(1);
+  });
+});

--- a/src/lib/__tests__/event-history-utils.test.ts
+++ b/src/lib/__tests__/event-history-utils.test.ts
@@ -1,0 +1,57 @@
+import { addEventToHistory, getEventHistory, removeEventFromHistory, clearEventHistory } from '../utils';
+
+describe('イベント履歴ユーティリティ', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('履歴が存在しない場合は空配列を返す', () => {
+    expect(getEventHistory()).toEqual([]);
+  });
+
+  it('イベントを追加すると履歴に保存される', () => {
+    const now = new Date().toISOString();
+    addEventToHistory({ id: '1', title: 'テスト', createdAt: now, isCreatedByMe: false });
+    const history = getEventHistory();
+    expect(history).toHaveLength(1);
+    expect(history[0].id).toBe('1');
+  });
+
+  it('同じIDのイベントは上書きされ先頭に来る', () => {
+    const now = new Date().toISOString();
+    addEventToHistory({ id: '1', title: 'A', createdAt: now, isCreatedByMe: false });
+    addEventToHistory({ id: '2', title: 'B', createdAt: now, isCreatedByMe: false });
+    addEventToHistory({ id: '1', title: 'C', createdAt: now, isCreatedByMe: false });
+    const history = getEventHistory();
+    expect(history[0].title).toBe('C');
+    expect(history).toHaveLength(2);
+  });
+
+  it('最大保持数を超えると古いものから削除される', () => {
+    const now = new Date().toISOString();
+    for (let i = 0; i < 12; i++) {
+      addEventToHistory({ id: String(i), title: `t${i}`, createdAt: now, isCreatedByMe: false });
+    }
+    const history = getEventHistory();
+    expect(history).toHaveLength(10);
+    expect(history[0].id).toBe('11');
+    expect(history[9].id).toBe('2');
+  });
+
+  it('特定のイベントを削除できる', () => {
+    const now = new Date().toISOString();
+    addEventToHistory({ id: '1', title: 'A', createdAt: now, isCreatedByMe: false });
+    addEventToHistory({ id: '2', title: 'B', createdAt: now, isCreatedByMe: false });
+    removeEventFromHistory('1');
+    const history = getEventHistory();
+    expect(history).toHaveLength(1);
+    expect(history[0].id).toBe('2');
+  });
+
+  it('履歴をクリアできる', () => {
+    const now = new Date().toISOString();
+    addEventToHistory({ id: '1', title: 'A', createdAt: now, isCreatedByMe: false });
+    clearEventHistory();
+    expect(getEventHistory()).toEqual([]);
+  });
+});

--- a/src/lib/__tests__/pagination-utils.test.ts
+++ b/src/lib/__tests__/pagination-utils.test.ts
@@ -1,0 +1,50 @@
+import { fetchAllPaginated, fetchAllPaginatedWithOrder, SupabaseQueryInterface } from '../utils';
+
+function createQueryForFetchAll(pages: Array<{ data: number[] | null; error: Error | null }>): SupabaseQueryInterface {
+  let call = 0;
+  return {
+    range: jest.fn().mockReturnThis(),
+    order: jest.fn(() => pages[call++] || { data: null, error: null }),
+  } as unknown as SupabaseQueryInterface;
+}
+
+function createQueryForFetchAllWithOrder(pages: Array<{ data: number[] | null; error: Error | null }>): SupabaseQueryInterface {
+  let call = 0;
+  return {
+    order: jest.fn().mockReturnThis(),
+    range: jest.fn(() => pages[call++] || { data: null, error: null }),
+  } as unknown as SupabaseQueryInterface;
+}
+
+describe('fetchAllPaginated', () => {
+  it('複数ページをまとめて取得できる', async () => {
+    const query = createQueryForFetchAll([
+      { data: [1, 2], error: null },
+      { data: [3], error: null },
+    ]);
+    const result = await fetchAllPaginated<number>(query, 2);
+    expect(result).toEqual([1, 2, 3]);
+    expect(query.range).toHaveBeenCalledTimes(2);
+    expect(query.order).toHaveBeenCalledTimes(2);
+  });
+
+  it('エラー時は例外を投げる', async () => {
+    const query = createQueryForFetchAll([
+      { data: null, error: new Error('NG') },
+    ]);
+    await expect(fetchAllPaginated<number>(query, 2)).rejects.toThrow('NG');
+  });
+});
+
+describe('fetchAllPaginatedWithOrder', () => {
+  it('順序指定付きでデータを取得できる', async () => {
+    const query = createQueryForFetchAllWithOrder([
+      { data: [1], error: null },
+      { data: [2], error: null },
+    ]);
+    const result = await fetchAllPaginatedWithOrder<number>(query, 'created_at', { ascending: false }, 1);
+    expect(result).toEqual([1, 2]);
+    expect(query.order).toHaveBeenCalledWith('created_at', { ascending: false });
+    expect(query.range).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## 背景
機能の信頼性向上のため、ユーティリティ周りのテストが不足していました。

## 変更内容
- イベント履歴操作のテスト追加
- デバイス判定ユーティリティのテスト追加
- ページネーション処理のテスト追加
- DOMユーティリティ(ensurePortal)のテスト追加

## テスト手順
1. `npm install`
2. `npm run lint`
3. `npm run test:ci`
4. `npm run e2e` (環境依存で失敗する可能性あり)

## 関連Issue
- #なし

------
https://chatgpt.com/codex/tasks/task_e_684257d6d054832aac61a66f48b4ac18