### PR TITLE
[test] work: テスト拡充

### DIFF
--- a/src/hooks/__tests__/useDeviceDetect.test.tsx
+++ b/src/hooks/__tests__/useDeviceDetect.test.tsx
@@ -1,0 +1,15 @@
+import { renderHook, act } from '@testing-library/react';
+import { useDeviceDetect } from '../useDeviceDetect';
+
+describe('useDeviceDetect', () => {
+  it('画面幅に応じてモバイル判定が切り替わる', () => {
+    Object.defineProperty(window, 'innerWidth', { value: 500, configurable: true });
+    const { result } = renderHook(() => useDeviceDetect());
+    expect(result.current.isMobile).toBe(true);
+    act(() => {
+      Object.defineProperty(window, 'innerWidth', { value: 800 });
+      window.dispatchEvent(new Event('resize'));
+    });
+    expect(result.current.isMobile).toBe(false);
+  });
+});

--- a/src/hooks/__tests__/useDragScrollBlocker.test.tsx
+++ b/src/hooks/__tests__/useDragScrollBlocker.test.tsx
@@ -1,0 +1,35 @@
+import { renderHook, act } from '@testing-library/react';
+import useDragScrollBlocker from '../useDragScrollBlocker';
+
+// JSDOM環境向けにPointerEventを簡易実装
+class TestPointerEvent extends Event {
+  clientX: number;
+  clientY: number;
+  pointerType: string;
+  constructor(type: string, props: any = {}) {
+    super(type, props);
+    this.clientX = props.clientX || 0;
+    this.clientY = props.clientY || 0;
+    this.pointerType = props.pointerType || 'mouse';
+  }
+}
+// @ts-ignore
+if (typeof window.PointerEvent === 'undefined') {
+  // @ts-ignore
+  window.PointerEvent = TestPointerEvent;
+}
+
+describe('useDragScrollBlocker', () => {
+  it('ドラッグ量が閾値を超えるとtrueになる', () => {
+    const { result } = renderHook(() => useDragScrollBlocker(10));
+    act(() => {
+      window.dispatchEvent(new PointerEvent('pointerdown', { pointerType: 'touch', clientX: 0, clientY: 0 }));
+      window.dispatchEvent(new PointerEvent('pointermove', { pointerType: 'touch', clientX: 20, clientY: 0 }));
+    });
+    expect(result.current).toBe(true);
+    act(() => {
+      window.dispatchEvent(new PointerEvent('pointerup'));
+    });
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,0 +1,154 @@
+import {
+  isMobileDevice,
+  isIOS,
+  isAndroid,
+  isStandalone,
+  formatDate,
+  formatDateTime,
+  formatDateWithDay,
+  formatDateTimeWithDay,
+  formatTime,
+  formatJapaneseDate,
+  formatJapaneseDateTime,
+  generateUuid,
+  addEventToHistory,
+  getEventHistory,
+  removeEventFromHistory,
+  clearEventHistory,
+  fetchAllPaginated,
+  fetchAllPaginatedWithOrder,
+  SupabaseQueryInterface,
+} from '../utils';
+
+interface MockQuery extends SupabaseQueryInterface {
+  _pages: Array<{ data: number[]; error: null }>;
+  _call: number;
+}
+
+function createRangeFirstQuery(pages: Array<{ data: number[]; error: null }>): MockQuery {
+  const query: Partial<MockQuery> = {
+    _pages: pages,
+    _call: 0,
+    range: jest.fn(function (this: MockQuery) {
+      return this;
+    }),
+    order: jest.fn(function (this: MockQuery) {
+      const res = this._pages[this._call++] || { data: [], error: null };
+      return Promise.resolve(res);
+    }),
+  };
+  return query as MockQuery;
+}
+
+function createOrderFirstQuery(pages: Array<{ data: number[]; error: null }>): MockQuery {
+  const query: Partial<MockQuery> = {
+    _pages: pages,
+    _call: 0,
+    order: jest.fn(function (this: MockQuery) {
+      return this;
+    }),
+    range: jest.fn(function (this: MockQuery) {
+      const res = this._pages[this._call++] || { data: [], error: null };
+      return Promise.resolve(res);
+    }),
+  };
+  return query as MockQuery;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('デバイス判定ユーティリティ', () => {
+  it('isMobileDevice判定', () => {
+    const original = window.navigator.userAgent;
+    Object.defineProperty(window.navigator, 'userAgent', { value: 'iPhone', configurable: true });
+    expect(isMobileDevice()).toBe(true);
+    Object.defineProperty(window.navigator, 'userAgent', { value: 'Mozilla', configurable: true });
+    expect(isMobileDevice()).toBe(false);
+    Object.defineProperty(window.navigator, 'userAgent', { value: original });
+  });
+
+  it('userAgent判定', () => {
+    const original = window.navigator.userAgent;
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: 'iPhone',
+      configurable: true,
+    });
+    expect(isIOS()).toBe(true);
+    expect(isAndroid()).toBe(false);
+    Object.defineProperty(window.navigator, 'userAgent', { value: 'Android' });
+    expect(isIOS()).toBe(false);
+    expect(isAndroid()).toBe(true);
+    Object.defineProperty(window.navigator, 'userAgent', { value: original });
+  });
+
+  it('isStandalone判定', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      value: () => ({ matches: true }),
+      configurable: true,
+    });
+    expect(isStandalone()).toBe(true);
+  });
+});
+
+describe('日付フォーマットユーティリティ', () => {
+  const date = new Date('2025-05-10T10:30:00');
+  it('formatDate系関数', () => {
+    expect(formatDate(date)).toBe('2025/05/10');
+    expect(formatDateTime(date)).toBe('2025/05/10 10:30');
+    expect(formatDateWithDay(date)).toMatch(/5\/10 \(.+\)/);
+    expect(formatDateTimeWithDay(date)).toMatch(/5\/10 \(.+\) 10:30/);
+    expect(formatTime(date)).toBe('10:30');
+    expect(formatJapaneseDate(date)).toMatch(/2025年5月10日/);
+    expect(formatJapaneseDateTime(date)).toMatch(/2025年5月10日.*10:30/);
+  });
+
+  it('UUID生成', () => {
+    const id = generateUuid();
+    expect(id).toMatch(/[0-9a-f]{8}-/);
+  });
+});
+
+describe('ローカルストレージ履歴操作', () => {
+  const item = {
+    id: '1',
+    title: 'test',
+    createdAt: new Date().toISOString(),
+    isCreatedByMe: false,
+  };
+  it('追加・取得・削除・クリアが動作する', () => {
+    addEventToHistory(item);
+    let history = getEventHistory();
+    expect(history.length).toBe(1);
+    removeEventFromHistory('1');
+    history = getEventHistory();
+    expect(history.length).toBe(0);
+    addEventToHistory(item);
+    clearEventHistory();
+    expect(getEventHistory().length).toBe(0);
+  });
+});
+
+describe('Supabaseページネーションユーティリティ', () => {
+  it('fetchAllPaginated', async () => {
+    const query = createRangeFirstQuery([
+      { data: [1, 2], error: null },
+      { data: [3], error: null },
+      { data: [], error: null },
+    ]);
+    const result = await fetchAllPaginated<number>(query, 2);
+    expect(result).toEqual([1, 2, 3]);
+    expect(query.range).toHaveBeenCalledTimes(2);
+  });
+
+  it('fetchAllPaginatedWithOrder', async () => {
+    const query = createOrderFirstQuery([
+      { data: [5], error: null },
+      { data: [], error: null },
+    ]);
+    const result = await fetchAllPaginatedWithOrder<number>(query, 'id', { ascending: false }, 1);
+    expect(result).toEqual([5]);
+    expect(query.order).toHaveBeenCalledWith('id', { ascending: false });
+  });
+});


### PR DESCRIPTION
## 概要
ユーティリティ関数とカスタムフックのテストを追加し、テストカバレッジを向上させました。

## 変更点
- `src/lib/utils.ts`向けのユニットテストを新規作成
- `useDeviceDetect`と`useDragScrollBlocker`用のテストを追加

## テスト
- `npm run lint`
- `npm run test:ci`
- `npm run test:e2e` *(環境の都合で失敗あり)*


------
https://chatgpt.com/codex/tasks/task_e_684269f8b22c832ab645438ad9b8a762