### PR TITLE
[fix] work: 曜日入力表の横幅調整

### DIFF
--- a/src/components/availability-form.tsx
+++ b/src/components/availability-form.tsx
@@ -1330,11 +1330,11 @@ export default function AvailabilityForm({
                     <div className="divider text-xs">曜日×時間帯表</div>
 
                     <div
-                      className="mb-4 overflow-x-auto overflow-y-hidden matrix-container touch-none"
+                      className="mb-4 -mx-4 overflow-x-hidden matrix-container touch-none"
                       style={{ touchAction: "none" }}
                     >
                       <table
-                        className="table table-xs border-collapse"
+                        className="table table-xs table-fixed w-full border-collapse"
                         onMouseDown={(e) => e.preventDefault()} // ドラッグ動作中のテキスト選択を防止
                         onTouchStart={(e) => e.preventDefault()} // タッチ操作中のスクロールを完全に防止
                       >


### PR DESCRIPTION
## 背景
画面幅が狭い場合に曜日ごとの時間帯設定表がはみ出し、横スクロールも無効化されているため全ての曜日を入力できませんでした。

## 変更点
- 入力表の外側余白を無くし、テーブルを `table-fixed` `w-full` として自動縮小
- これにより小画面でも全曜日が表示されます

## テスト
- `npm run lint`
- `npm run test:ci`
- `npm run e2e` （失敗）

------
https://chatgpt.com/codex/tasks/task_e_6848c60af7dc832a9abef12bf8a99aa3