### PR TITLE
[fix] work: LINEブラウザ判定スクリプトの配置変更

### DIFF
--- a/src/components/browser-banner/LineExternalBrowserRedirector.tsx
+++ b/src/components/browser-banner/LineExternalBrowserRedirector.tsx
@@ -1,20 +1,23 @@
-"use client";
-import { useEffect } from "react";
+import Head from "next/head";
 
 /**
  * LINEアプリ内ブラウザでアクセスされた場合、
  * openExternalBrowser=1 クエリを自動付与してリダイレクトする
  */
 export default function LineExternalBrowserRedirector() {
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const ua = window.navigator.userAgent.toLowerCase();
-    const isLine = ua.includes("line");
-    if (!isLine) return;
-    const url = new URL(window.location.href);
-    if (url.searchParams.get("openExternalBrowser") === "1") return;
-    url.searchParams.set("openExternalBrowser", "1");
-    window.location.replace(url.toString());
-  }, []);
-  return null;
+  const script = `(
+    function() {
+      const ua = navigator.userAgent.toLowerCase();
+      if (!ua.includes('line')) return;
+      const url = new URL(window.location.href);
+      if (url.searchParams.get('openExternalBrowser') === '1') return;
+      url.searchParams.set('openExternalBrowser', '1');
+      window.location.replace(url.toString());
+    }
+  )();`;
+  return (
+    <Head>
+      <script dangerouslySetInnerHTML={{ __html: script }} />
+    </Head>
+  );
 }


### PR DESCRIPTION
## 背景
`beforeInteractive` スクリプトが `layout.tsx` で警告となっていたため、`Head` 経由で読み込む方式に変更しました。

## 変更点
- `LineExternalBrowserRedirector` を `next/head` を用いた実装に修正

## テスト
- `npm run lint` を実行しエラー無しを確認
- `npm run test:ci` を実行し全テスト成功
- `npm run e2e` を実行するも多数失敗

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685147f3e2bc832aaedd8c26d600bbd5