### PR TITLE
[refactor] work: Lineブラウザ判定スクリプトをnext/script化

### DIFF
--- a/src/components/__tests__/line-external-browser-redirector.test.tsx
+++ b/src/components/__tests__/line-external-browser-redirector.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { render } from "@testing-library/react";
+
+jest.mock("next/script", () => {
+  return function MockScript(props: {
+    id?: string;
+    strategy?: string;
+    dangerouslySetInnerHTML?: { __html: string };
+    children?: React.ReactNode;
+  }) {
+    const { id, children, dangerouslySetInnerHTML, strategy } = props;
+    return (
+      <script id={id} data-strategy={strategy}>
+        {dangerouslySetInnerHTML ? dangerouslySetInnerHTML.__html : children}
+      </script>
+    );
+  };
+});
+
+import LineExternalBrowserRedirector from "../browser-banner/LineExternalBrowserRedirector";
+
+describe("LineExternalBrowserRedirector", () => {
+  it("LINEブラウザ検知用スクリプトが挿入される", () => {
+    const { container } = render(<LineExternalBrowserRedirector />);
+    const script = container.querySelector(
+      "script#line-external-browser-redirector"
+    );
+    expect(script).not.toBeNull();
+    expect(script?.textContent).toContain("openExternalBrowser");
+    expect(script).toHaveAttribute("data-strategy", "afterInteractive");
+  });
+});

--- a/src/components/browser-banner/LineExternalBrowserRedirector.tsx
+++ b/src/components/browser-banner/LineExternalBrowserRedirector.tsx
@@ -1,4 +1,4 @@
-import Head from "next/head";
+import Script from "next/script";
 
 /**
  * LINEアプリ内ブラウザでアクセスされた場合、
@@ -16,8 +16,10 @@ export default function LineExternalBrowserRedirector() {
     }
   )();`;
   return (
-    <Head>
-      <script dangerouslySetInnerHTML={{ __html: script }} />
-    </Head>
+    <Script
+      id="line-external-browser-redirector"
+      strategy="afterInteractive"
+      dangerouslySetInnerHTML={{ __html: script }}
+    />
   );
 }


### PR DESCRIPTION
## 背景
LINE 内ブラウザ利用時に標準ブラウザへリダイレクトする処理を `next/head` で実装していました。
Next.js 推奨の `next/script` を利用するよう修正しました。

## 変更点
- `LineExternalBrowserRedirector` を `next/script` で実装
- 上記コンポーネントの単体テストを追加

## テスト手順
1. `npm run lint`
2. `npm run test:ci`
3. `npm run e2e` *(失敗しました)*

## 関連Issue
なし

------
https://chatgpt.com/codex/tasks/task_e_6851580779dc832a88af75b5e739c76b