### PR TITLE
[fix] work: tsconfigのincludeパス修正

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    "../app/actions.ts"
+    "src/app/actions.ts"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## 背景
`tsconfig.json` の `include` 配列内に誤ったパス `../app/actions.ts` が指定されており、不要な型チェック対象となっていました。

## 変更内容
- `tsconfig.json` の `include` を `src/app/actions.ts` に修正
- `npm ci` 実行後に `npm run lint` と `npm run test:ci` を実行し、エラーが無いことを確認

## テスト手順
1. `npm ci`
2. `npm run lint`
3. `npm run test:ci`

以上が成功すれば問題ありません。


------
https://chatgpt.com/codex/tasks/task_e_685170b6d56c832a83821bf6eb11610c