### PR TITLE
[fix] work: actionsコメント削除

### DIFF
--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { createSupabaseAdmin } from './supabase';
-import { v4 as uuidv4 } from 'uuid'; // You may need to install this package: npm install uuid @types/uuid
+import { v4 as uuidv4 } from 'uuid';
 
 export async function createEvent(formData: FormData) {
   const title = formData.get('title') as string;


### PR DESCRIPTION
## 背景
`src/lib/actions.ts` の先頭に開発用のコメントが残っていたため削除しました。

## 変更内容
- `uuid` インポート行の不要なコメントを削除

## テスト
- `npm run lint`
- `npm run test:ci`
- `npm run e2e:ci` (環境依存で失敗)


------
https://chatgpt.com/codex/tasks/task_e_685170bca2bc832a96f83c2325fb4e61