### PR TITLE
[feat] work: GitHub Actionsでe2eテスト追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
     name: E2E
     runs-on: ubuntu-latest
     needs: [lint, test]
+    env:
+      PORT: 3001
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -51,6 +53,6 @@ jobs:
       - run: supabase status -o env --override-name api.url=SUPABASE_URL --override-name anon.key=SUPABASE_ANON_KEY --override-name service_role.key=SUPABASE_SERVICE_ROLE_KEY >> $GITHUB_ENV
       - run: npm run build
       - run: npm run start &
-      - run: npx wait-on http://localhost:3000
-      - run: npm run e2e:ci
+      - run: npx wait-on http://localhost:${{ env.PORT }}
+      - run: npm run test:e2e:chrome
       - run: supabase stop

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ e2e テストは Playwright を使用しており、以下のようなテスト�
   - CI/CD での利用を想定した簡易レポート出力です。
 
 - **GitHub Actions での自動E2E テスト**
-  `.github/workflows/ci.yml` に Supabase と Next.js アプリを起動して `npm run e2e:ci` を実行するジョブを用意しています。
+  `.github/workflows/ci.yml` に Supabase と Next.js アプリを起動して `npm run test:e2e:chrome` を実行するジョブを用意しています。ポート競合を避けるため `PORT=3001` を指定しています。
 
 - **テストレポートの確認**
   テスト実行後、以下のコマンドで HTML レポートをブラウザで確認できます。


### PR DESCRIPTION
## Summary
- GitHub Actions に Supabase を起動する `E2E` ジョブを追加
- README に GitHub Actions で自動実行されることを追記

## Testing
- `npm run lint`
- `npm run test:ci`
- `npm run e2e` *(失敗: Supabase が起動できないため)*

------
https://chatgpt.com/codex/tasks/task_e_685243feb42c832ab599bc466fb32083