### PR TITLE
[test] feature/add-tests: jest追加テスト

### DIFF
--- a/src/app/__tests__/404.test.tsx
+++ b/src/app/__tests__/404.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import NotFound from '../not-found';
+
+jest.mock('next/link', () => {
+  return {
+    __esModule: true,
+    default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+      <a href={href}>{children}</a>
+    ),
+  };
+});
+
+describe('NotFound page', () => {
+  it('404ページの内容が表示される', () => {
+    render(<NotFound />);
+    expect(screen.getByText('404')).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /トップページに戻る/ });
+    expect(link).toHaveAttribute('href', '/');
+  });
+});

--- a/src/app/__tests__/500.test.tsx
+++ b/src/app/__tests__/500.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ServerError from '../500';
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+describe('ServerError page', () => {
+  it('500ページの内容が表示される', () => {
+    render(<ServerError />);
+    expect(screen.getByText('500')).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /トップページに戻る/ });
+    expect(link).toHaveAttribute('href', '/');
+  });
+});

--- a/src/app/__tests__/unauthorized.test.tsx
+++ b/src/app/__tests__/unauthorized.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Unauthorized from '../unauthorized/page';
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+describe('Unauthorized page', () => {
+  it('権限エラーページが表示される', () => {
+    render(<Unauthorized />);
+    expect(screen.getByText('アクセス権限がありません')).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /トップページに戻る/ });
+    expect(link).toHaveAttribute('href', '/');
+  });
+});

--- a/src/lib/__tests__/site-config.test.ts
+++ b/src/lib/__tests__/site-config.test.ts
@@ -1,0 +1,13 @@
+import siteConfig from '../site-config';
+
+describe('site-config', () => {
+  it('基本情報が定義されている', () => {
+    expect(siteConfig.name.full).toBe('DaySynth');
+    expect(siteConfig.url).toMatch(/^https?:\/\//);
+  });
+
+  it('著作権年が現在の年', () => {
+    const year = new Date().getFullYear();
+    expect(Number(siteConfig.copyright.year)).toBe(year);
+  });
+});

--- a/src/lib/__tests__/supabase.test.ts
+++ b/src/lib/__tests__/supabase.test.ts
@@ -1,0 +1,41 @@
+import { createClient } from '@supabase/supabase-js';
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({ client: true })),
+}));
+
+describe('supabase.ts', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    (createClient as jest.Mock).mockClear();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('環境変数不足時はエラー', async () => {
+    delete process.env.SUPABASE_URL;
+    const { createSupabaseAdmin } = await import('../supabase');
+    expect(() => createSupabaseAdmin()).toThrow();
+  });
+
+  it('adminクライアントを生成する', async () => {
+    process.env.SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service';
+    const { createSupabaseAdmin } = await import('../supabase');
+    const client = createSupabaseAdmin();
+    expect(client).toEqual({ client: true });
+  });
+
+  it('anonクライアントを生成する', async () => {
+    process.env.SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_ANON_KEY = 'anon';
+    const { createSupabaseClient } = await import('../supabase');
+    const client = createSupabaseClient();
+    expect(client).toEqual({ client: true });
+  });
+});


### PR DESCRIPTION
## 概要
- 未テストだった各ページ(404/500/Unauthorized)のユニットテストを追加
- site-configとsupabaseユーティリティのテストを新規作成

## 変更点
- src/app/__tests__ に3つのページテストを追加
- src/lib/__tests__ に設定・Supabase用テストを追加

## 動作確認
- `npm run lint`
- `npm run test:ci`
- `npm run e2e` は環境上失敗するが試行済み


------
https://chatgpt.com/codex/tasks/task_e_6854ff3b8f90832a990af4adb083c86b