### PR TITLE
[fix] work: SVGアイコン表示崩れの修正

### DIFF
--- a/src/app/event/[public_id]/input/input-form.tsx
+++ b/src/app/event/[public_id]/input/input-form.tsx
@@ -145,7 +145,7 @@ export default function InputForm({
               strokeLinecap="round"
               strokeLinejoin="round"
               strokeWidth="2"
-              d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"
+              d="M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
             />
           </svg>
           <span>{errorMessage}</span>

--- a/src/components/availability-form.tsx
+++ b/src/components/availability-form.tsx
@@ -1070,7 +1070,7 @@ export default function AvailabilityForm({
                 strokeLinecap="round"
                 strokeLinejoin="round"
                 strokeWidth={2}
-                d="M9 12l2 2 4-4m6 2a9 9 0 1 1-18 0 1 9 0 0 1 18 0z"
+                  d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
               />
             </svg>
             <span>{feedback}</span>
@@ -1130,7 +1130,7 @@ export default function AvailabilityForm({
                   strokeLinecap="round"
                   strokeLinejoin="round"
                   strokeWidth="2"
-                  d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 1 1-18 0 1 9 0 0 1 18 0z"
+                  d="M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
                 />
               </svg>
               <span>{error}</span>

--- a/src/components/copy-availability-form.tsx
+++ b/src/components/copy-availability-form.tsx
@@ -131,7 +131,7 @@ export default function CopyAvailabilityForm({
               strokeLinecap="round"
               strokeLinejoin="round"
               strokeWidth="2"
-              d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"
+              d="M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
             />
           </svg>
           <span>{error}</span>

--- a/src/components/event-form-client.tsx
+++ b/src/components/event-form-client.tsx
@@ -106,7 +106,7 @@ export default function EventFormClient() {
               strokeLinecap="round"
               strokeLinejoin="round"
               strokeWidth="2"
-              d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"
+              d="M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
             />
           </svg>
           <span>{error}</span>

--- a/src/components/finalize-event-section.tsx
+++ b/src/components/finalize-event-section.tsx
@@ -674,7 +674,7 @@ export default function FinalizeEventSection({
                   strokeLinecap="round"
                   strokeLinejoin="round"
                   strokeWidth="2"
-                  d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"
+                  d="M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
                 />
               </svg>
               <span>{error}</span>

--- a/src/components/landing/landing-page-client.tsx
+++ b/src/components/landing/landing-page-client.tsx
@@ -224,7 +224,7 @@ export default function LandingPageClient() {
               >
                 <Card className="hover:scale-[1.03] transition-transform h-full">
                   <div className="flex flex-col items-center gap-4">
-                    <f.icon className="w-12 h-12 text-primary" />
+                    <f.icon size={48} className="text-primary" />
                     <h3 className="font-bold text-xl">{f.title}</h3>
                     <p className="text-base-content/80 text-center">{f.desc}</p>
                   </div>
@@ -270,7 +270,7 @@ export default function LandingPageClient() {
               >
                 <Card className="hover:scale-[1.03] transition-transform h-full">
                   <div className="flex flex-col items-center gap-4">
-                    <u.icon className="w-12 h-12 text-primary" />
+                    <u.icon size={48} className="text-primary" />
                     <h3 className="font-bold text-xl">{u.title}</h3>
                     <p className="text-base-content/80 text-center">{u.desc}</p>
                   </div>


### PR DESCRIPTION
## 背景
エラーメッセージ等で表示されるSVGアイコンが正しく描画されない問題がありました。また、ランディングページの機能紹介・利用シーンで使用している`lucide-react`のアイコンサイズ指定が誤っていました。

## 変更内容
- エラー表示用アイコンのパスをHeroiconsの定義に合わせて修正
- `lucide-react`製アイコンに`size`プロパティを指定
- 影響箇所のテスト・lintを実行

## 動作確認手順
1. `npm run lint`
2. `npm run test:ci`

## 関連Issue
- なし

------
https://chatgpt.com/codex/tasks/task_e_685b904b8244832a8887d6c40f1a1a0c