### PR TITLE
[feat] feature/share-available-dates: 時間帯統合ロジック修正

### DIFF
--- a/src/lib/__tests__/share-utils.test.ts
+++ b/src/lib/__tests__/share-utils.test.ts
@@ -1,37 +1,93 @@
-import { buildAvailableDatesMessage } from '../share-utils';
+import { buildAvailableDatesMessage } from "../share-utils";
 
-describe('buildAvailableDatesMessage', () => {
+describe("buildAvailableDatesMessage", () => {
   const dates = [
-    { id: 'd1', start_time: '2025-05-01T10:00:00', end_time: '2025-05-01T11:00:00' },
-    { id: 'd2', start_time: '2025-05-02T12:00:00', end_time: '2025-05-02T13:00:00' },
+    {
+      id: "d1",
+      start_time: "2025-05-01T10:00:00",
+      end_time: "2025-05-01T11:00:00",
+    },
+    {
+      id: "d2",
+      start_time: "2025-05-02T12:00:00",
+      end_time: "2025-05-02T13:00:00",
+    },
   ];
   const availabilities = [
-    { participant_id: 'p1', event_date_id: 'd1', availability: true },
-    { participant_id: 'p2', event_date_id: 'd1', availability: true },
-    { participant_id: 'p1', event_date_id: 'd2', availability: false },
-    { participant_id: 'p2', event_date_id: 'd2', availability: true },
+    { participant_id: "p1", event_date_id: "d1", availability: true },
+    { participant_id: "p2", event_date_id: "d1", availability: true },
+    { participant_id: "p1", event_date_id: "d2", availability: false },
+    { participant_id: "p2", event_date_id: "d2", availability: true },
   ];
 
-  it('参加人数2人、閾値2で1件のみ返す', () => {
+  it("参加人数2人、閾値2で1件のみ返す", () => {
     expect(buildAvailableDatesMessage(dates, availabilities, 2)).toBe(
-      '[2人以上が参加可能な日程]\n- 5月1日 10:00-11:00'
+      "[2人以上が参加可能な日程]\n- 5月1日 10:00-11:00",
     );
   });
 
-  it('閾値1なら2件返す', () => {
+  it("閾値1なら2件返す", () => {
     expect(buildAvailableDatesMessage(dates, availabilities, 1)).toBe(
-      '[1人以上が参加可能な日程]\n- 5月1日 10:00-11:00\n- 5月2日 12:00-13:00'
+      "[1人以上が参加可能な日程]\n- 5月1日 10:00-11:00\n- 5月2日 12:00-13:00",
     );
   });
 
-  it('該当なしの場合は該当なしメッセージを返す', () => {
+  it("該当なしの場合は該当なしメッセージを返す", () => {
     expect(buildAvailableDatesMessage(dates, availabilities, 3)).toBe(
-      '[3人以上が参加可能な日程]\n該当する日程がありません'
+      "[3人以上が参加可能な日程]\n該当する日程がありません",
     );
   });
 
-  it('minCountが0以下の場合は空文字を返す', () => {
-    expect(buildAvailableDatesMessage(dates, availabilities, 0)).toBe('');
-    expect(buildAvailableDatesMessage(dates, availabilities, -1)).toBe('');
+  it("minCountが0以下の場合は空文字を返す", () => {
+    expect(buildAvailableDatesMessage(dates, availabilities, 0)).toBe("");
+    expect(buildAvailableDatesMessage(dates, availabilities, -1)).toBe("");
+  });
+
+  it("同じ日付の連続する時間帯をまとめる", () => {
+    const multiDates = [
+      {
+        id: "d1",
+        start_time: "2025-05-01T10:00:00",
+        end_time: "2025-05-01T11:00:00",
+      },
+      {
+        id: "d2",
+        start_time: "2025-05-01T11:00:00",
+        end_time: "2025-05-01T12:00:00",
+      },
+    ];
+    const multiAvailabilities = [
+      { participant_id: "p1", event_date_id: "d1", availability: true },
+      { participant_id: "p2", event_date_id: "d1", availability: true },
+      { participant_id: "p1", event_date_id: "d2", availability: true },
+      { participant_id: "p2", event_date_id: "d2", availability: true },
+    ];
+    expect(buildAvailableDatesMessage(multiDates, multiAvailabilities, 2)).toBe(
+      "[2人以上が参加可能な日程]\n- 5月1日 10:00-12:00",
+    );
+  });
+
+  it("間が空いた時間帯はまとめない", () => {
+    const gapDates = [
+      {
+        id: "d1",
+        start_time: "2025-05-01T10:00:00",
+        end_time: "2025-05-01T11:00:00",
+      },
+      {
+        id: "d2",
+        start_time: "2025-05-01T12:00:00",
+        end_time: "2025-05-01T13:00:00",
+      },
+    ];
+    const gapAvailabilities = [
+      { participant_id: "p1", event_date_id: "d1", availability: true },
+      { participant_id: "p2", event_date_id: "d1", availability: true },
+      { participant_id: "p1", event_date_id: "d2", availability: true },
+      { participant_id: "p2", event_date_id: "d2", availability: true },
+    ];
+    expect(buildAvailableDatesMessage(gapDates, gapAvailabilities, 2)).toBe(
+      "[2人以上が参加可能な日程]\n- 5月1日 10:00-11:00, 12:00-13:00",
+    );
   });
 });

--- a/src/lib/share-utils.ts
+++ b/src/lib/share-utils.ts
@@ -1,4 +1,3 @@
-
 export type ShareEventDate = {
   id: string;
   start_time: string;
@@ -22,35 +21,66 @@ export type ShareAvailability = {
 export function buildAvailableDatesMessage(
   dates: ShareEventDate[],
   availabilities: ShareAvailability[],
-  minCount: number
+  minCount: number,
 ): string {
   if (minCount <= 0) return "";
 
-  const lines: string[] = [];
+  // 日付ごとに参加可能な時間帯を配列で保持
+  const grouped = new Map<string, { start: Date; end: Date }[]>();
 
   dates.forEach((date) => {
     const count = availabilities.filter(
-      (a) => a.event_date_id === date.id && a.availability
+      (a) => a.event_date_id === date.id && a.availability,
     ).length;
     if (count >= minCount) {
       const start = new Date(date.start_time);
       const end = new Date(date.end_time);
-      const dateLabel = `${start.getMonth() + 1}月${start.getDate()}日`;
-      const startTime = `${start.getHours().toString().padStart(2, "0")}:${start
-        .getMinutes()
-        .toString()
-        .padStart(2, "0")}`;
-      const endTime = `${end.getHours().toString().padStart(2, "0")}:${end
-        .getMinutes()
-        .toString()
-        .padStart(2, "0")}`;
-      lines.push(`- ${dateLabel} ${startTime}-${endTime}`);
+      const label = `${start.getMonth() + 1}月${start.getDate()}日`;
+      const arr = grouped.get(label) ?? [];
+      arr.push({ start, end });
+      grouped.set(label, arr);
     }
   });
 
-  if (lines.length === 0) {
+  if (grouped.size === 0) {
     return `[${minCount}人以上が参加可能な日程]\n該当する日程がありません`;
   }
+
+  const lines = Array.from(grouped.entries())
+    // 日付順に並べ替え（各日付の最初の時間帯で判定）
+    .sort((a, b) => a[1][0].start.getTime() - b[1][0].start.getTime())
+    .map(([label, ranges]) => {
+      // 開始時刻順に並べ替え
+      ranges.sort((a, b) => a.start.getTime() - b.start.getTime());
+
+      // 隣接・重複する時間帯を統合
+      const merged: { start: Date; end: Date }[] = [];
+      for (const r of ranges) {
+        const last = merged[merged.length - 1];
+        if (last && r.start.getTime() <= last.end.getTime()) {
+          if (r.end > last.end) last.end = r.end;
+        } else {
+          merged.push({ start: r.start, end: r.end });
+        }
+      }
+
+      const rangeStrings = merged.map((m) => {
+        const startStr = `${m.start
+          .getHours()
+          .toString()
+          .padStart(2, "0")}:${m.start
+          .getMinutes()
+          .toString()
+          .padStart(2, "0")}`;
+        const endStr = `${m.end.getHours().toString().padStart(2, "0")}:${m.end
+          .getMinutes()
+          .toString()
+          .padStart(2, "0")}`;
+        return `${startStr}-${endStr}`;
+      });
+
+      return `- ${label} ${rangeStrings.join(", ")}`;
+    });
 
   return `[${minCount}人以上が参加可能な日程]` + "\n" + lines.join("\n");
 }


### PR DESCRIPTION
## 背景
同日付の時間帯を1行にまとめる処理が、離れた時間帯まで1つに結合していました。

## 変更内容
- `buildAvailableDatesMessage` 内で日付ごとの時間帯リストを作成し、連続または重複している範囲のみを結合するよう修正
- 連続する時間帯の結合および離れている時間帯が結合されないことを確認するユニットテストを追加

## テスト内容
- `npm run lint` は `next` コマンドが見つからず実行できず
- `npm run test:ci` は `jest` コマンドが見つからず実行できず

## 関連Issue
- なし

------
https://chatgpt.com/codex/tasks/task_e_686780f4d5b8832ab4927e74db8b16ed