### PR TITLE
feat: イベント日程の取得とスケジュールブロックの処理を改善

### DIFF
--- a/src/lib/__tests__/schedule-actions.test.ts
+++ b/src/lib/__tests__/schedule-actions.test.ts
@@ -28,6 +28,12 @@ const createRangeMock = <T,>(pages: T[][]) =>
     }),
   );
 
+const createOrderedRangeChain = (rangeMock: jest.Mock) => {
+  const secondOrderMock = jest.fn().mockReturnValue({ range: rangeMock });
+  const firstOrderMock = jest.fn().mockReturnValue({ order: secondOrderMock });
+  return { firstOrderMock, secondOrderMock };
+};
+
 describe('saveAvailabilityOverrides', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -296,15 +302,17 @@ describe('applyUserAvailabilitySyncForEvent', () => {
       }
       if (table === 'user_event_availability_overrides') {
         const rangeMock = createRangeMock([[]]);
-        const inMock = jest.fn().mockReturnValue({ range: rangeMock });
+        const { firstOrderMock } = createOrderedRangeChain(rangeMock);
+        const inMock = jest.fn().mockReturnValue({ order: firstOrderMock });
         const eqMock = jest.fn().mockReturnValue({ in: inMock });
         return { select: jest.fn().mockReturnValue({ eq: eqMock }) };
       }
       if (table === 'availabilities' && fromMock.mock.calls.length === 7) {
         const rangeMock = createRangeMock([currentAvailabilities]);
+        const { firstOrderMock } = createOrderedRangeChain(rangeMock);
         return {
           select: jest.fn().mockReturnValue({
-            in: jest.fn().mockReturnValue({ range: rangeMock }),
+            in: jest.fn().mockReturnValue({ order: firstOrderMock }),
           }),
         };
       }
@@ -440,15 +448,17 @@ describe('fetchUserAvailabilitySyncPreviewResult', () => {
       }
       if (table === 'user_event_availability_overrides') {
         const rangeMock = createRangeMock([[]]);
-        const inMock = jest.fn().mockReturnValue({ range: rangeMock });
+        const { firstOrderMock } = createOrderedRangeChain(rangeMock);
+        const inMock = jest.fn().mockReturnValue({ order: firstOrderMock });
         const eqMock = jest.fn().mockReturnValue({ in: inMock });
         return { select: jest.fn().mockReturnValue({ eq: eqMock }) };
       }
       if (table === 'availabilities') {
         const rangeMock = createRangeMock([[]]);
+        const { firstOrderMock } = createOrderedRangeChain(rangeMock);
         return {
           select: jest.fn().mockReturnValue({
-            in: jest.fn().mockReturnValue({ range: rangeMock }),
+            in: jest.fn().mockReturnValue({ order: firstOrderMock }),
           }),
         };
       }
@@ -571,15 +581,17 @@ describe('fetchUserAvailabilitySyncPreviewResult', () => {
       }
       if (table === 'user_event_availability_overrides') {
         const rangeMock = createRangeMock([[]]);
-        const inMock = jest.fn().mockReturnValue({ range: rangeMock });
+        const { firstOrderMock } = createOrderedRangeChain(rangeMock);
+        const inMock = jest.fn().mockReturnValue({ order: firstOrderMock });
         const eqMock = jest.fn().mockReturnValue({ in: inMock });
         return { select: jest.fn().mockReturnValue({ eq: eqMock }) };
       }
       if (table === 'availabilities') {
         const rangeMock = createRangeMock([[]]);
+        const { firstOrderMock } = createOrderedRangeChain(rangeMock);
         return {
           select: jest.fn().mockReturnValue({
-            in: jest.fn().mockReturnValue({ range: rangeMock }),
+            in: jest.fn().mockReturnValue({ order: firstOrderMock }),
           }),
         };
       }

--- a/src/lib/__tests__/schedule-actions.test.ts
+++ b/src/lib/__tests__/schedule-actions.test.ts
@@ -20,6 +20,14 @@ jest.mock('@/lib/supabase', () => ({
 const mockedGetAuthSession = getAuthSession as jest.Mock;
 const mockedCreateSupabaseAdmin = createSupabaseAdmin as jest.Mock;
 
+const createRangeMock = <T,>(pages: T[][]) =>
+  jest.fn((from: number) =>
+    Promise.resolve({
+      data: pages[Math.floor(from / 1000)] ?? [],
+      error: null,
+    }),
+  );
+
 describe('saveAvailabilityOverrides', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -224,16 +232,19 @@ describe('applyUserAvailabilitySyncForEvent', () => {
         return { select: jest.fn().mockReturnValue({ eq: eqMock }) };
       }
       if (table === 'user_schedule_blocks') {
-        const eqMock = jest.fn().mockResolvedValue({
-          data: [
+        const rangeMock = createRangeMock([
+          [
             {
               start_time: '2099-05-09T13:00:00',
               end_time: '2099-05-09T14:00:00',
               availability: true,
             },
           ],
-          error: null,
-        });
+        ]);
+        const orderMock = jest.fn().mockReturnValue({ range: rangeMock });
+        const gtMock = jest.fn().mockReturnValue({ order: orderMock });
+        const ltMock = jest.fn().mockReturnValue({ gt: gtMock });
+        const eqMock = jest.fn().mockReturnValue({ lt: ltMock });
         return { select: jest.fn().mockReturnValue({ eq: eqMock }) };
       }
       if (table === 'finalized_dates') {
@@ -259,39 +270,41 @@ describe('applyUserAvailabilitySyncForEvent', () => {
         };
       }
       if (table === 'event_dates') {
+        const rangeMock = createRangeMock([
+          [
+            {
+              id: pastDateId,
+              event_id: eventId,
+              start_time: '2000-05-09T13:00:00',
+              end_time: '2000-05-09T14:00:00',
+            },
+            {
+              id: futureDateId,
+              event_id: eventId,
+              start_time: '2099-05-09T13:00:00',
+              end_time: '2099-05-09T14:00:00',
+            },
+          ],
+        ]);
         return {
           select: jest.fn().mockReturnValue({
             in: jest.fn().mockReturnValue({
-              order: jest.fn().mockResolvedValue({
-                data: [
-                  {
-                    id: pastDateId,
-                    event_id: eventId,
-                    start_time: '2000-05-09T13:00:00',
-                    end_time: '2000-05-09T14:00:00',
-                  },
-                  {
-                    id: futureDateId,
-                    event_id: eventId,
-                    start_time: '2099-05-09T13:00:00',
-                    end_time: '2099-05-09T14:00:00',
-                  },
-                ],
-                error: null,
-              }),
+              order: jest.fn().mockReturnValue({ range: rangeMock }),
             }),
           }),
         };
       }
       if (table === 'user_event_availability_overrides') {
-        const inMock = jest.fn().mockResolvedValue({ data: [], error: null });
+        const rangeMock = createRangeMock([[]]);
+        const inMock = jest.fn().mockReturnValue({ range: rangeMock });
         const eqMock = jest.fn().mockReturnValue({ in: inMock });
         return { select: jest.fn().mockReturnValue({ eq: eqMock }) };
       }
       if (table === 'availabilities' && fromMock.mock.calls.length === 7) {
+        const rangeMock = createRangeMock([currentAvailabilities]);
         return {
           select: jest.fn().mockReturnValue({
-            in: jest.fn().mockResolvedValue({ data: currentAvailabilities, error: null }),
+            in: jest.fn().mockReturnValue({ range: rangeMock }),
           }),
         };
       }
@@ -358,8 +371,8 @@ describe('fetchUserAvailabilitySyncPreviewResult', () => {
         return { select: jest.fn().mockReturnValue({ eq: eqMock }) };
       }
       if (table === 'user_schedule_blocks') {
-        const eqMock = jest.fn().mockResolvedValue({
-          data: [
+        const rangeMock = createRangeMock([
+          [
             {
               start_time: '2099-06-03T14:00:00+00:00',
               end_time: '2099-06-03T15:00:00+00:00',
@@ -371,8 +384,11 @@ describe('fetchUserAvailabilitySyncPreviewResult', () => {
               availability: true,
             },
           ],
-          error: null,
-        });
+        ]);
+        const orderMock = jest.fn().mockReturnValue({ range: rangeMock });
+        const gtMock = jest.fn().mockReturnValue({ order: orderMock });
+        const ltMock = jest.fn().mockReturnValue({ gt: gtMock });
+        const eqMock = jest.fn().mockReturnValue({ lt: ltMock });
         return { select: jest.fn().mockReturnValue({ eq: eqMock }) };
       }
       if (table === 'finalized_dates') {
@@ -398,39 +414,41 @@ describe('fetchUserAvailabilitySyncPreviewResult', () => {
         };
       }
       if (table === 'event_dates') {
+        const rangeMock = createRangeMock([
+          [
+            {
+              id: firstDateId,
+              event_id: eventId,
+              start_time: '2099-06-03T14:00:00',
+              end_time: '2099-06-03T15:00:00',
+            },
+            {
+              id: secondDateId,
+              event_id: eventId,
+              start_time: '2099-06-03T15:00:00',
+              end_time: '2099-06-03T16:00:00',
+            },
+          ],
+        ]);
         return {
           select: jest.fn().mockReturnValue({
             in: jest.fn().mockReturnValue({
-              order: jest.fn().mockResolvedValue({
-                data: [
-                  {
-                    id: firstDateId,
-                    event_id: eventId,
-                    start_time: '2099-06-03T14:00:00',
-                    end_time: '2099-06-03T15:00:00',
-                  },
-                  {
-                    id: secondDateId,
-                    event_id: eventId,
-                    start_time: '2099-06-03T15:00:00',
-                    end_time: '2099-06-03T16:00:00',
-                  },
-                ],
-                error: null,
-              }),
+              order: jest.fn().mockReturnValue({ range: rangeMock }),
             }),
           }),
         };
       }
       if (table === 'user_event_availability_overrides') {
-        const inMock = jest.fn().mockResolvedValue({ data: [], error: null });
+        const rangeMock = createRangeMock([[]]);
+        const inMock = jest.fn().mockReturnValue({ range: rangeMock });
         const eqMock = jest.fn().mockReturnValue({ in: inMock });
         return { select: jest.fn().mockReturnValue({ eq: eqMock }) };
       }
       if (table === 'availabilities') {
+        const rangeMock = createRangeMock([[]]);
         return {
           select: jest.fn().mockReturnValue({
-            in: jest.fn().mockResolvedValue({ data: [], error: null }),
+            in: jest.fn().mockReturnValue({ range: rangeMock }),
           }),
         };
       }
@@ -460,6 +478,126 @@ describe('fetchUserAvailabilitySyncPreviewResult', () => {
       }),
       expect.objectContaining({
         eventDateId: secondDateId,
+        currentAvailability: false,
+        desiredAvailability: true,
+      }),
+    ]);
+  });
+
+  it('イベント候補と予定ブロックが1000件を超えても差分を検出する', async () => {
+    const eventId = 'event-1';
+    const participantId = 'participant-1';
+    const targetDateId = 'date-after-first-page';
+    const toDateTime = (date: Date) => date.toISOString().slice(0, 19);
+    const toUtcDateTime = (date: Date) => `${toDateTime(date)}+00:00`;
+    const fillerDates = Array.from({ length: 1000 }, (_, index) => ({
+      id: `date-${index}`,
+      event_id: eventId,
+      start_time: toDateTime(new Date(Date.UTC(2099, 0, 1, index))),
+      end_time: toDateTime(new Date(Date.UTC(2099, 0, 1, index + 1))),
+    }));
+    const fillerBlocks = Array.from({ length: 1000 }, (_, index) => ({
+      start_time: toUtcDateTime(new Date(Date.UTC(2099, 1, 1, index))),
+      end_time: toUtcDateTime(new Date(Date.UTC(2099, 1, 1, index + 1))),
+      availability: false,
+    }));
+    const eventDateRangeMock = createRangeMock([
+      fillerDates,
+      [
+        {
+          id: targetDateId,
+          event_id: eventId,
+          start_time: '2099-06-03T14:00:00',
+          end_time: '2099-06-03T15:00:00',
+        },
+      ],
+    ]);
+    const blockRangeMock = createRangeMock([
+      fillerBlocks,
+      [
+        {
+          start_time: '2099-06-03T14:00:00+00:00',
+          end_time: '2099-06-03T15:00:00+00:00',
+          availability: true,
+        },
+      ],
+    ]);
+
+    const fromMock = jest.fn((table: string) => {
+      if (table === 'user_event_links') {
+        const eqMock = jest.fn().mockResolvedValue({
+          data: [{ event_id: eventId, participant_id: participantId }],
+          error: null,
+        });
+        return { select: jest.fn().mockReturnValue({ eq: eqMock }) };
+      }
+      if (table === 'event_dates') {
+        return {
+          select: jest.fn().mockReturnValue({
+            in: jest.fn().mockReturnValue({
+              order: jest.fn().mockReturnValue({ range: eventDateRangeMock }),
+            }),
+          }),
+        };
+      }
+      if (table === 'user_schedule_blocks') {
+        const orderMock = jest.fn().mockReturnValue({ range: blockRangeMock });
+        const gtMock = jest.fn().mockReturnValue({ order: orderMock });
+        const ltMock = jest.fn().mockReturnValue({ gt: gtMock });
+        const eqMock = jest.fn().mockReturnValue({ lt: ltMock });
+        return { select: jest.fn().mockReturnValue({ eq: eqMock }) };
+      }
+      if (table === 'finalized_dates') {
+        return {
+          select: jest.fn().mockReturnValue({ in: jest.fn().mockResolvedValue({ data: [] }) }),
+        };
+      }
+      if (table === 'events') {
+        return {
+          select: jest.fn().mockReturnValue({
+            in: jest.fn().mockResolvedValue({
+              data: [
+                {
+                  id: eventId,
+                  title: 'ページング対象イベント',
+                  public_token: 'event-token',
+                  is_finalized: false,
+                },
+              ],
+              error: null,
+            }),
+          }),
+        };
+      }
+      if (table === 'user_event_availability_overrides') {
+        const rangeMock = createRangeMock([[]]);
+        const inMock = jest.fn().mockReturnValue({ range: rangeMock });
+        const eqMock = jest.fn().mockReturnValue({ in: inMock });
+        return { select: jest.fn().mockReturnValue({ eq: eqMock }) };
+      }
+      if (table === 'availabilities') {
+        const rangeMock = createRangeMock([[]]);
+        return {
+          select: jest.fn().mockReturnValue({
+            in: jest.fn().mockReturnValue({ range: rangeMock }),
+          }),
+        };
+      }
+      throw new Error(`unexpected table: ${table}`);
+    });
+    mockedCreateSupabaseAdmin.mockReturnValue({ from: fromMock });
+
+    const result = await fetchUserAvailabilitySyncPreviewResult();
+
+    expect(eventDateRangeMock).toHaveBeenCalledWith(0, 999);
+    expect(eventDateRangeMock).toHaveBeenCalledWith(1000, 1999);
+    expect(blockRangeMock).toHaveBeenCalledWith(0, 999);
+    expect(blockRangeMock).toHaveBeenCalledWith(1000, 1999);
+    expect(result.success).toBe(true);
+    expect(result.events[0]?.changes.unavailableToAvailable).toBe(1);
+    expect(result.events[0]?.dates.filter((date) => date.willChange)).toEqual([
+      expect.objectContaining({
+        eventDateId: targetDateId,
         currentAvailability: false,
         desiredAvailability: true,
       }),

--- a/src/lib/schedule-actions.ts
+++ b/src/lib/schedule-actions.ts
@@ -232,6 +232,8 @@ const fetchSyncPreviewOverrideRows = async (
       .select('event_id,event_date_id')
       .eq('user_id', userId)
       .in('event_id', eventIds)
+      .order('event_id', { ascending: true })
+      .order('event_date_id', { ascending: true })
       .range(from, to);
 
     if (error) {
@@ -258,6 +260,8 @@ const fetchSyncPreviewAvailabilityRows = async (
       .from('availabilities')
       .select('participant_id,event_date_id,availability')
       .in('participant_id', participantIds)
+      .order('participant_id', { ascending: true })
+      .order('event_date_id', { ascending: true })
       .range(from, to);
 
     if (error) {
@@ -286,6 +290,8 @@ const fetchAvailabilityOverrideRows = async (
       .select('event_id,event_date_id,availability')
       .eq('user_id', userId)
       .in('event_id', eventIds)
+      .order('event_id', { ascending: true })
+      .order('event_date_id', { ascending: true })
       .range(from, to);
 
     if (error) {

--- a/src/lib/schedule-actions.ts
+++ b/src/lib/schedule-actions.ts
@@ -14,6 +14,7 @@ import {
 
 type EventDateRange = {
   id: string;
+  event_id?: string;
   start_time: string;
   end_time: string;
 };
@@ -180,6 +181,159 @@ type SyncPreviewContext = {
   currentAvailabilitiesByParticipantId: Map<string, Map<string, boolean>>;
 };
 
+const SUPABASE_PAGE_SIZE = 1000;
+
+const fetchEventDateRanges = async (
+  supabase: ReturnType<typeof createSupabaseAdmin>,
+  eventIds: string[],
+): Promise<EventDateRange[]> => {
+  const rows: EventDateRange[] = [];
+  if (eventIds.length === 0) return rows;
+
+  for (let from = 0; ; from += SUPABASE_PAGE_SIZE) {
+    const to = from + SUPABASE_PAGE_SIZE - 1;
+    const { data, error } = await supabase
+      .from('event_dates')
+      .select('id,event_id,start_time,end_time')
+      .in('event_id', eventIds)
+      .order('start_time', { ascending: true })
+      .range(from, to);
+
+    if (error) {
+      console.error('イベント日程取得エラー:', error);
+      return rows;
+    }
+
+    rows.push(
+      ...((data ?? []).map((row) => ({
+        id: row.id,
+        event_id: row.event_id,
+        start_time: row.start_time,
+        end_time: row.end_time,
+      })) as EventDateRange[]),
+    );
+
+    if (!data || data.length < SUPABASE_PAGE_SIZE) return rows;
+  }
+};
+
+const fetchSyncPreviewOverrideRows = async (
+  supabase: ReturnType<typeof createSupabaseAdmin>,
+  userId: string,
+  eventIds: string[],
+): Promise<Array<{ event_id: string; event_date_id: string }>> => {
+  const rows: Array<{ event_id: string; event_date_id: string }> = [];
+  if (eventIds.length === 0) return rows;
+
+  for (let from = 0; ; from += SUPABASE_PAGE_SIZE) {
+    const to = from + SUPABASE_PAGE_SIZE - 1;
+    const { data, error } = await supabase
+      .from('user_event_availability_overrides')
+      .select('event_id,event_date_id')
+      .eq('user_id', userId)
+      .in('event_id', eventIds)
+      .range(from, to);
+
+    if (error) {
+      console.error('上書き情報取得エラー:', error);
+      return rows;
+    }
+
+    rows.push(...((data ?? []) as typeof rows));
+
+    if (!data || data.length < SUPABASE_PAGE_SIZE) return rows;
+  }
+};
+
+const fetchSyncPreviewAvailabilityRows = async (
+  supabase: ReturnType<typeof createSupabaseAdmin>,
+  participantIds: string[],
+): Promise<Array<{ participant_id: string; event_date_id: string; availability: boolean }>> => {
+  const rows: Array<{ participant_id: string; event_date_id: string; availability: boolean }> = [];
+  if (participantIds.length === 0) return rows;
+
+  for (let from = 0; ; from += SUPABASE_PAGE_SIZE) {
+    const to = from + SUPABASE_PAGE_SIZE - 1;
+    const { data, error } = await supabase
+      .from('availabilities')
+      .select('participant_id,event_date_id,availability')
+      .in('participant_id', participantIds)
+      .range(from, to);
+
+    if (error) {
+      console.error('現在回答取得エラー:', error);
+      return rows;
+    }
+
+    rows.push(...((data ?? []) as typeof rows));
+
+    if (!data || data.length < SUPABASE_PAGE_SIZE) return rows;
+  }
+};
+
+const fetchAvailabilityOverrideRows = async (
+  supabase: ReturnType<typeof createSupabaseAdmin>,
+  userId: string,
+  eventIds: string[],
+): Promise<Array<{ event_id: string; event_date_id: string; availability: boolean }>> => {
+  const rows: Array<{ event_id: string; event_date_id: string; availability: boolean }> = [];
+  if (eventIds.length === 0) return rows;
+
+  for (let from = 0; ; from += SUPABASE_PAGE_SIZE) {
+    const to = from + SUPABASE_PAGE_SIZE - 1;
+    const { data, error } = await supabase
+      .from('user_event_availability_overrides')
+      .select('event_id,event_date_id,availability')
+      .eq('user_id', userId)
+      .in('event_id', eventIds)
+      .range(from, to);
+
+    if (error) {
+      console.error('上書き情報取得エラー:', error);
+      return rows;
+    }
+
+    rows.push(...((data ?? []) as typeof rows));
+
+    if (!data || data.length < SUPABASE_PAGE_SIZE) return rows;
+  }
+};
+
+const fetchScheduleBlocksInRange = async ({
+  supabase,
+  userId,
+  minStart,
+  maxEnd,
+}: {
+  supabase: ReturnType<typeof createSupabaseAdmin>;
+  userId: string;
+  minStart: string;
+  maxEnd: string;
+}): Promise<ScheduleBlock[]> => {
+  const rows: ScheduleBlock[] = [];
+
+  for (let from = 0; ; from += SUPABASE_PAGE_SIZE) {
+    const to = from + SUPABASE_PAGE_SIZE - 1;
+    const { data, error } = await supabase
+      .from('user_schedule_blocks')
+      .select('start_time,end_time,availability')
+      .eq('user_id', userId)
+      .lt('start_time', maxEnd)
+      .gt('end_time', minStart)
+      .order('start_time', { ascending: true })
+      .range(from, to);
+
+    if (error) {
+      console.error('予定ブロック取得エラー:', error);
+      return rows;
+    }
+
+    rows.push(...((data ?? []) as ScheduleBlock[]));
+
+    if (!data || data.length < SUPABASE_PAGE_SIZE) return rows;
+  }
+};
+
 const buildSyncPreviewContext = async (
   userId: string,
   options?: SyncPreviewBuildOptions,
@@ -236,10 +390,33 @@ const buildSyncPreviewContext = async (
   const scopedEventIds = Array.from(new Set(links.map((row) => row.event_id)));
   const scopedParticipantIds = Array.from(new Set(links.map((row) => row.participant_id)));
 
-  const { data: blocks } = await supabase
-    .from('user_schedule_blocks')
-    .select('start_time,end_time,availability')
-    .eq('user_id', userId);
+  const allEventDates = await fetchEventDateRanges(supabase, scopedEventIds);
+  const eventDatesByEventId = new Map<string, EventDateRange[]>();
+  allEventDates.forEach((row) => {
+    if (!row.event_id) return;
+    const current = eventDatesByEventId.get(row.event_id) ?? [];
+    current.push({
+      id: row.id,
+      event_id: row.event_id,
+      start_time: row.start_time,
+      end_time: row.end_time,
+    });
+    eventDatesByEventId.set(row.event_id, current);
+  });
+
+  const blocks =
+    allEventDates.length > 0
+      ? await fetchScheduleBlocksInRange({
+          supabase,
+          userId,
+          minStart: allEventDates
+            .map((row) => row.start_time)
+            .reduce((min, value) => (value < min ? value : min), allEventDates[0].start_time),
+          maxEnd: allEventDates
+            .map((row) => row.end_time)
+            .reduce((max, value) => (value > max ? value : max), allEventDates[0].end_time),
+        })
+      : [];
 
   const { data: finalizedDates } =
     allEventIds.length > 0
@@ -272,49 +449,20 @@ const buildSyncPreviewContext = async (
   }
   const eventsMap = new Map((eventsData ?? []).map((row) => [row.id, row]));
 
-  const { data: allEventDates, error: datesError } = await supabase
-    .from('event_dates')
-    .select('id,event_id,start_time,end_time')
-    .in('event_id', scopedEventIds)
-    .order('start_time', { ascending: true });
-  if (datesError) {
-    console.error('イベント日程取得エラー:', datesError);
-  }
-  const eventDatesByEventId = new Map<string, EventDateRange[]>();
-  (allEventDates ?? []).forEach((row) => {
-    const current = eventDatesByEventId.get(row.event_id) ?? [];
-    current.push({
-      id: row.id,
-      start_time: row.start_time,
-      end_time: row.end_time,
-    });
-    eventDatesByEventId.set(row.event_id, current);
-  });
-
-  const { data: overrides, error: overridesError } = await supabase
-    .from('user_event_availability_overrides')
-    .select('event_id,event_date_id')
-    .eq('user_id', userId)
-    .in('event_id', scopedEventIds);
-  if (overridesError) {
-    console.error('上書き情報取得エラー:', overridesError);
-  }
+  const overrides = await fetchSyncPreviewOverrideRows(supabase, userId, scopedEventIds);
   const protectedDateIdsByEventId = new Map<string, Set<string>>();
-  (overrides ?? []).forEach((row) => {
+  overrides.forEach((row) => {
     const set = protectedDateIdsByEventId.get(row.event_id) ?? new Set<string>();
     set.add(row.event_date_id);
     protectedDateIdsByEventId.set(row.event_id, set);
   });
 
-  const { data: currentAvailabilities, error: currentAvailabilitiesError } = await supabase
-    .from('availabilities')
-    .select('participant_id,event_date_id,availability')
-    .in('participant_id', scopedParticipantIds);
-  if (currentAvailabilitiesError) {
-    console.error('現在回答取得エラー:', currentAvailabilitiesError);
-  }
+  const currentAvailabilities = await fetchSyncPreviewAvailabilityRows(
+    supabase,
+    scopedParticipantIds,
+  );
   const currentAvailabilitiesByParticipantId = new Map<string, Map<string, boolean>>();
-  (currentAvailabilities ?? []).forEach((row) => {
+  currentAvailabilities.forEach((row) => {
     const map = currentAvailabilitiesByParticipantId.get(row.participant_id) ?? new Map();
     map.set(row.event_date_id, row.availability);
     currentAvailabilitiesByParticipantId.set(row.participant_id, map);
@@ -323,7 +471,7 @@ const buildSyncPreviewContext = async (
   return {
     links,
     eventsMap,
-    blocks: (blocks ?? []) as ScheduleBlock[],
+    blocks,
     busyIntervals,
     eventDatesByEventId,
     protectedDateIdsByEventId,
@@ -835,10 +983,20 @@ export async function syncUserAvailabilities({
   const targetEventIds = Array.from(new Set(links.map((link) => link.event_id)));
   const participantIds = Array.from(new Set(links.map((link) => link.participant_id)));
 
-  const { data: blocks } = await supabase
-    .from('user_schedule_blocks')
-    .select('start_time,end_time,availability')
-    .eq('user_id', userId);
+  const eventDatesRows = await fetchEventDateRanges(supabase, targetEventIds);
+  const blocks =
+    eventDatesRows.length > 0
+      ? await fetchScheduleBlocksInRange({
+          supabase,
+          userId,
+          minStart: eventDatesRows
+            .map((row) => row.start_time)
+            .reduce((min, value) => (value < min ? value : min), eventDatesRows[0].start_time),
+          maxEnd: eventDatesRows
+            .map((row) => row.end_time)
+            .reduce((max, value) => (value > max ? value : max), eventDatesRows[0].end_time),
+        })
+      : [];
 
   const { data: finalizedDates } =
     allEventIds.length > 0
@@ -862,49 +1020,30 @@ export async function syncUserAvailabilities({
       Boolean(row),
     );
 
-  const { data: eventDatesRows, error: eventDatesError } = await supabase
-    .from('event_dates')
-    .select('id,event_id,start_time,end_time')
-    .in('event_id', targetEventIds);
-  if (eventDatesError) {
-    console.error('イベント日程取得エラー:', eventDatesError);
-    return;
-  }
   const eventDatesByEventId = new Map<string, EventDateRange[]>();
-  (eventDatesRows ?? []).forEach((row) => {
+  eventDatesRows.forEach((row) => {
+    if (!row.event_id) return;
     const current = eventDatesByEventId.get(row.event_id) ?? [];
     current.push({
       id: row.id,
+      event_id: row.event_id,
       start_time: row.start_time,
       end_time: row.end_time,
     });
     eventDatesByEventId.set(row.event_id, current);
   });
 
-  const { data: overridesRows, error: overridesError } = await supabase
-    .from('user_event_availability_overrides')
-    .select('event_id,event_date_id,availability')
-    .eq('user_id', userId)
-    .in('event_id', targetEventIds);
-  if (overridesError) {
-    console.error('上書き情報取得エラー:', overridesError);
-  }
+  const overridesRows = await fetchAvailabilityOverrideRows(supabase, userId, targetEventIds);
   const overrideMapByEventId = new Map<string, Map<string, boolean>>();
-  (overridesRows ?? []).forEach((row) => {
+  overridesRows.forEach((row) => {
     const map = overrideMapByEventId.get(row.event_id) ?? new Map<string, boolean>();
     map.set(row.event_date_id, row.availability);
     overrideMapByEventId.set(row.event_id, map);
   });
 
-  const { data: currentAvailabilitiesRows, error: currentAvailabilitiesError } = await supabase
-    .from('availabilities')
-    .select('participant_id,event_date_id,availability')
-    .in('participant_id', participantIds);
-  if (currentAvailabilitiesError) {
-    console.error('現在回答取得エラー:', currentAvailabilitiesError);
-  }
+  const currentAvailabilitiesRows = await fetchSyncPreviewAvailabilityRows(supabase, participantIds);
   const currentAvailabilitiesByParticipantId = new Map<string, Set<string>>();
-  (currentAvailabilitiesRows ?? []).forEach((row) => {
+  currentAvailabilitiesRows.forEach((row) => {
     if (!row.availability) return;
     const set = currentAvailabilitiesByParticipantId.get(row.participant_id) ?? new Set<string>();
     set.add(row.event_date_id);
@@ -946,7 +1085,7 @@ export async function syncUserAvailabilities({
       const auto = computeAccountBlockAutoFill({
         start: date.start_time,
         end: date.end_time,
-        blocks: (blocks ?? []) as ScheduleBlock[],
+        blocks,
       });
 
       if (auto === true) {


### PR DESCRIPTION
- イベント日程をページネーションで取得する関数を追加
- ユーザーのスケジュールブロックを範囲で取得する処理を追加
- コードの重複を削減し、可読性を向上

## 目的

この PR で解決したいことを簡潔に書いてください。

## 変更内容

-
-

## 確認内容

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:ci`
- [ ] 必要に応じて E2E テスト

## 影響範囲

想定される影響や注意点を書いてください。

## 補足

スクリーンショット、関連 issue、未解決の TODO があれば記載してください。
