### PR TITLE
fix: イベント日程管理の見出しを明確化

### DIFF
--- a/src/components/event-client/event-details-section.tsx
+++ b/src/components/event-client/event-details-section.tsx
@@ -110,7 +110,7 @@ export default function EventDetailsSection({
       </section>
       {/* --- イベント管理・修正セクション --- */}
       <section className="surface my-8 p-5 sm:p-6">
-        <h2 className="section-heading mb-1">主催者向けの操作</h2>
+        <h2 className="section-heading mb-1">イベント日程の管理</h2>
         <p className="section-description mb-6">日程を確定するか、候補日を追加できます。</p>
         <div className="flex flex-col gap-8 md:flex-row">
           {/* 日程確定セクション */}


### PR DESCRIPTION
## 目的

イベントページの管理セクションが、ユーザーの目的を直感的に表す見出しになるよう改善します。

## 変更内容

- 「主催者向けの操作」を「イベント日程の管理」へ変更
- 機能やレイアウトには変更なし

## ブランチ運用

- [x] `main` から作成した短命ブランチで作業している
- [x] Draft PR で早めに共有した

## 確認内容

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:ci`
- [ ] 必要に応じて E2E テスト
- [x] 変更ファイル単体の ESLint

## 影響範囲

イベント詳細ページの管理セクション見出しのみです。機能、データ、APIへの影響はありません。

## 補足

- 関連 Issue: なし
- 変更後のスクリーンショットをPRコメントに掲載しています。
- `main` は Squash merge を前提としています。
